### PR TITLE
BIP39 seed

### DIFF
--- a/compile.py
+++ b/compile.py
@@ -13,7 +13,7 @@ f.close()
 
 # Script tags
 
-scriptsFinder = re.compile("""<script src="/(.*)"></script>""")
+scriptsFinder = re.compile("""<script src="(.*)"></script>""")
 scripts = scriptsFinder.findall(page)
 
 for script in scripts:
@@ -21,13 +21,13 @@ for script in scripts:
     s = open(filename)
     scriptContent = "<script>%s</script>" % s.read()
     s.close()
-    scriptTag = """<script src="/%s"></script>""" % script
+    scriptTag = """<script src="%s"></script>""" % script
     page = page.replace(scriptTag, scriptContent)
 
 
 # Style tags
 
-stylesFinder = re.compile("""<link rel="stylesheet" href="/(.*)">""")
+stylesFinder = re.compile("""<link rel="stylesheet" href="(.*)">""")
 styles = stylesFinder.findall(page)
 
 for style in styles:
@@ -35,7 +35,7 @@ for style in styles:
     s = open(filename)
     styleContent = "<style>%s</style>" % s.read()
     s.close()
-    styleTag = """<link rel="stylesheet" href="/%s">""" % style
+    styleTag = """<link rel="stylesheet" href="%s">""" % style
     page = page.replace(styleTag, styleContent)
 
 

--- a/src/index.html
+++ b/src/index.html
@@ -89,6 +89,12 @@
                             </div>
                         </div>
                         <div class="form-group">
+                            <label for="seed" class="col-sm-2 control-label">BIP39 Seed</label>
+                            <div class="col-sm-10">
+                                <textarea id="seed" class="seed form-control" readonly="readonly"></textarea>
+                            </div>
+                        </div>
+                        <div class="form-group">
                             <label for="network-phrase" class="col-sm-2 control-label">Coin</label>
                             <div class="col-sm-10">
                                 <select id="network-phrase" class="network form-control">

--- a/src/index.html
+++ b/src/index.html
@@ -3,7 +3,7 @@
     <head lang="en">
         <meta charset="utf-8" />
         <title>BIP39 - Mnemonic Code</title>
-        <link rel="stylesheet" href="/css/bootstrap.min.css">
+        <link rel="stylesheet" href="css/bootstrap.min.css">
         <meta content="Mnemonic code for generating deterministic keys" name="description"/>
         <meta content="width=device-width, initial-scale=1.0" name="viewport" />
         <meta content="bitcoin mnemonic converter" name="description" />
@@ -385,13 +385,13 @@
                 <td class="privkey"><span></span></td>
             </tr>
         </script>
-        <script src="/js/jquery.min.js"></script>
-        <script src="/js/bootstrap.min.js"></script>
-        <script src="/js/bitcoinjs-1-5-7.js"></script>
-        <script src="/js/bitcoinjs-extensions.js"></script>
-        <script src="/js/sjcl-bip39.js"></script>
-        <script src="/js/wordlist_english.js"></script>
-        <script src="/js/jsbip39.js"></script>
-        <script src="/js/index.js"></script>
+        <script src="js/jquery.min.js"></script>
+        <script src="js/bootstrap.min.js"></script>
+        <script src="js/bitcoinjs-1-5-7.js"></script>
+        <script src="js/bitcoinjs-extensions.js"></script>
+        <script src="js/sjcl-bip39.js"></script>
+        <script src="js/wordlist_english.js"></script>
+        <script src="js/jsbip39.js"></script>
+        <script src="js/index.js"></script>
     </body>
 </html>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,6 +1,7 @@
 (function() {
 
     var mnemonic = new Mnemonic("english");
+    var seed = null
     var bip32RootKey = null;
     var bip32ExtendedKey = null;
     var network = bitcoin.networks.bitcoin;
@@ -18,6 +19,7 @@
     DOM.phrase = $(".phrase");
     DOM.passphrase = $(".passphrase");
     DOM.generate = $(".generate");
+    DOM.seed = $(".seed");
     DOM.rootKey = $(".root-key");
     DOM.extendedPrivKey = $(".extended-priv-key");
     DOM.extendedPubKey = $(".extended-pub-key");
@@ -169,7 +171,7 @@
     }
 
     function calcBip32Seed(phrase, passphrase, path) {
-        var seed = mnemonic.toSeed(phrase, passphrase);
+        seed = mnemonic.toSeed(phrase, passphrase);
         bip32RootKey = bitcoin.HDNode.fromSeedHex(seed, network);
         bip32ExtendedKey = bip32RootKey;
         // Derive the key from the path
@@ -232,6 +234,7 @@
 
     function displayBip32Info() {
         // Display the key
+        DOM.seed.val(seed);
         var rootKey = bip32RootKey.toBase58();
         DOM.rootKey.val(rootKey);
         var extendedPrivKey = bip32ExtendedKey.toBase58();


### PR DESCRIPTION
There are cases when BIP39 seed may be necessary to know. For example, Legder HW.1 wallet provisioning system does support password encoded mnemonics, however HW.1 [can be initialized using BIP32 seed](https://github.com/LedgerHQ/btchip-c-api#initialization-commands).

I also made js and css paths relative so that non-standalone version can be used directly from file-system.